### PR TITLE
BZ2 updating footer spacing to avoid conflict with intercom

### DIFF
--- a/app/_assets/stylesheets/_footer.scss
+++ b/app/_assets/stylesheets/_footer.scss
@@ -5,6 +5,7 @@
   .container {
     width: 100%;
     max-width: 1400px;
+    padding-right: 95px;
   }
 
   .site-footer-content {


### PR DESCRIPTION
The Intercom logo in the lower right corner was overlapping the footer nav. Added some spacing to the right side.
