### PR TITLE
fix: route info is now nested under a data prop

### DIFF
--- a/src/utils/document.js
+++ b/src/utils/document.js
@@ -16,9 +16,7 @@ export function Document({ Html, Head, Body, children, state }) {
 
   const { integrations = {}, info = {} } = siteData;
   const { intercom, hubspot, googleTagManager } = integrations || {};
-
-  const routeData = (routeInfo && routeInfo.allProps) || {};
-  const { pagination = {}, meta: routeMeta, path } = routeData;
+  const { pagination = {}, meta: routeMeta, path } = (routeInfo && routeInfo.data) || {};
 
   const meta = resolveMeta(siteData.meta, routeMeta);
   const { jld } = meta;

--- a/src/utils/markdown/index.js
+++ b/src/utils/markdown/index.js
@@ -54,6 +54,11 @@ export const convertMarkdownToHTML = (data, options) => {
 
   for (const key in data) {
     if (data.hasOwnProperty(key)) {
+      // No need to resolve meta data
+      if (key === 'meta') {
+        continue;
+      }
+
       if (typeof data[key] === 'object') {
         data[key] = convertMarkdownToHTML(data[key], options);
       } else if (['description', 'markdown'].includes(key)) {


### PR DESCRIPTION
- Gets the route meta data from the correct location
- Ignore meta description when resolving markdown