### PR TITLE
Fix/spectral landing metadata

### DIFF
--- a/netlify/landings/spectral.yaml
+++ b/netlify/landings/spectral.yaml
@@ -76,7 +76,8 @@ meta:
   description: >-
     Spectral is an open source OpenAPI linter, which can tell you not just if
     your API descriptions are valid, but if they are any good.
-  favicon: /images/spectral_cli.png
+  favicon: /images/mark_light_bg.png
+  image: /images/spectral_cli.png  
   title: Spectral - Open Source API Description Linter | Stoplight
   twitter:
     description: >-

--- a/netlify/landings/spectral.yaml
+++ b/netlify/landings/spectral.yaml
@@ -74,16 +74,14 @@ featureSection:
 
 meta:
   description: >-
-    Spectral is an open-source OpenAPI-linter, which can tell you not just if
-    your API descriptions are valid, but if they are any good. Use our baked-in rulesets for
-    OpenAPI Specification v2/v3 (formerly known as Swagger specification), or write your own!
+    Spectral is an open source OpenAPI linter, which can tell you not just if
+    your API descriptions are valid, but if they are any good.
   favicon: /images/spectral_cli.png
   title: Spectral - Open Source API Description Linter | Stoplight
   twitter:
     description: >-
-      Spectral is an open-source OpenAPI-linter, which can tell you not just if
-      your API descriptions are valid, but if they are any good. Use our baked-in rulesets for
-      OpenAPI Specification v2/v3 (formerly known as Swagger specification), or write your own!
+      Spectral is an open source OpenAPI linter, which can tell you not just if
+      your API descriptions are valid, but if they are any good.
     image: /images/spectral_cli.png
     title: Spectral - Open Source API Description Linter | Stoplight
     username: '@stoplightio'

--- a/netlify/landings/spectral.yaml
+++ b/netlify/landings/spectral.yaml
@@ -77,13 +77,13 @@ meta:
     Spectral is an open-source OpenAPI-linter, which can tell you not just if
     your API descriptions are valid, but if they are any good. Use our baked-in rulesets for
     OpenAPI Specification v2/v3 (formerly known as Swagger specification), or write your own!
-  favicon: /images/mark_light_bg.png
+  favicon: /images/spectral_cli.png
   title: Spectral - Open Source API Description Linter | Stoplight
   twitter:
     description: >-
       Spectral is an open-source OpenAPI-linter, which can tell you not just if
       your API descriptions are valid, but if they are any good. Use our baked-in rulesets for
       OpenAPI Specification v2/v3 (formerly known as Swagger specification), or write your own!
-    image: /images/mocking_instant.png
+    image: /images/spectral_cli.png
     title: Spectral - Open Source API Description Linter | Stoplight
     username: '@stoplightio'


### PR DESCRIPTION
This didn't look so great, so I fixed it: 

![image](https://user-images.githubusercontent.com/2008034/61392293-17cd7100-a884-11e9-83fc-cabc1d326b62.png)

