### PR TITLE
fix: remove hubspot requirement from submit form

### DIFF
--- a/src/components/Submit/config.js
+++ b/src/components/Submit/config.js
@@ -13,6 +13,7 @@ export default {
       name: 'formId',
       label: 'Hubspot FormId',
       widget: 'string',
+      required: false,
     },
   ],
 };


### PR DESCRIPTION
Fixes #1080 

@rowa97 This should do it now. Let me know if you still have trouble. 