### PR TITLE
docs: added docs link to studio landing

### DIFF
--- a/netlify/landings/studio.yaml
+++ b/netlify/landings/studio.yaml
@@ -31,6 +31,10 @@ hero:
       icon: ['fab', 'linux']
       color: green
       filename: studio-linux
+    - color: indigo
+      href: 'https://stoplight.io/p/docs/gh/stoplightio/studio'
+      title: Read the Docs
+      icon: ['fad', 'book-open']
 featureSection:
   actionBar:
     ctas:


### PR DESCRIPTION
During the webinar I went looking for the docs link and couldn't find it! 😅 