### PR TITLE
hopefully the last studio release link update

### DIFF
--- a/netlify/landings/studio.yaml
+++ b/netlify/landings/studio.yaml
@@ -17,17 +17,17 @@ hero:
       icon: ['fad', 'browser']
       color: purple
     - title: Mac App
-      href: 'https://github.com/stoplightio/studio/releases/download/v1.3.0/Stoplight-Studio-1.3.0.dmg'
+      href: 'https://github.com/stoplightio/studio/releases/latest/download/stoplight-studio-mac.dmg'
       icon: ['fab', 'apple']
       color: green
       filename: studio-mac
     - title: Windows App
-      href: 'https://github.com/stoplightio/studio/releases/download/v1.3.0/Stoplight-Studio-Setup-1.3.0.exe'
+      href: 'https://github.com/stoplightio/studio/releases/latest/download/stoplight-studio-win.exe'
       icon: ['fab', 'windows']
       color: green
       filename: studio-windows
     - title: Linux App
-      href: 'https://github.com/stoplightio/studio/releases/download/v1.3.0/Stoplight-Studio-1.3.0.AppImage'
+      href: 'https://github.com/stoplightio/studio/releases/latest/download/stoplight-studio-linux-x86_64.AppImage'
       icon: ['fab', 'linux']
       color: green
       filename: studio-linux


### PR DESCRIPTION
Now that we've stripped version number from the artifact name we don't need to keep updating the site on every release. 

Closes https://github.com/stoplightio/enablers/issues/35
Closes https://github.com/stoplightio/stoplight.io/issues/1152