### PR TITLE
fix: reduce z index so tabs are clickable

### DIFF
--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -25,7 +25,7 @@ export const Content: React.FunctionComponent<IContent> = ({ sidebar, includeToc
     <>
       {!sidebar && includeToc ? (
         <div
-          className="sticky z-10 flex flex-col items-end w-1/6 m-auto -mb-40 -mr-20 md:-mr-6 sm:-mb-48 sm:py-8"
+          className="sticky flex flex-col items-end w-1/6 m-auto -mb-40 -mr-20 z-1 md:-mr-6 sm:-mb-48 sm:py-8"
           style={{ top: isBannerShowing ? 140 : 80, marginRight: 0, marginTop: 76, marginBottom: -200 }}
         >
           <div className="p-4 bg-white border rounded-lg md:hidden">

--- a/src/templates/Subpage/index.tsx
+++ b/src/templates/Subpage/index.tsx
@@ -79,7 +79,7 @@ export const Subpage: React.FunctionComponent<IPage> = ({
 
       <Section noPadding>
         <Container className="mx-auto my-10 sm:-mb-1">
-          <div className="relative pb-20">
+          <div className="relative pb-1">
             {sidebar && (
               <div className="float-right w-1/3 mb-12 ml-12 -mt-32 sm:mt-0 sm:ml-0 sm:mb-24 sm:w-full sm:float-none">
                 {sidebar.info ? <Info {...sidebar.info} /> : null}
@@ -102,9 +102,8 @@ export const Subpage: React.FunctionComponent<IPage> = ({
                 <Image className="rounded-lg shadow bodyImage" src={bodyImage} alt={bodyImage} />
               </div>
             )}
-
-            <Content body={body} sidebar={sidebar} includeToc={includeToc} className={className} />
           </div>
+          <Content body={body} sidebar={sidebar} includeToc={includeToc} className={className} />
         </Container>
       </Section>
 


### PR DESCRIPTION
Content sticky CTA box still appears but you should now be able to click tabs on subpages